### PR TITLE
chore: moyopy installation requires the interface option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "structuregraph-helpers>=0.0.9",
     "average-minimum-distance>=1.5.3",
     "datasets>=3.2.0",
-    "moyopy>=0.2.3",
+    "moyopy[interface]>=0.2.3",
     "pip>=24.3.1",
     # build dependencies
     "setuptools",


### PR DESCRIPTION
Hello,

For the installation instructions to work without further intervention, moyopy needs to be installed with the `interface` flag.

This PR simply adds that to the pyproject.toml.